### PR TITLE
Remove http client dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "php-http/multipart-stream-builder": "^1.4",
         "riverline/multipart-parser": "^2.1",
         "php-soap/psr18-transport": "^1.7",
-        "symfony/http-client": "^7.2",
         "azjezz/psl": "^3.1"
     },
     "require-dev": {
@@ -38,7 +37,7 @@
     },
     "config": {
         "allow-plugins": {
-            "php-http/discovery": true
+            "php-http/discovery": false
         }
     }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | #4 

#### Summary

I've removed here the specific symfony/http-client dependency.  I would guess that it was added in automatically by the php-http/discovery plugin.  It seems to helpfully add that line back in when running update or install.

Unless I misunderstand I think it's fine and preferred here to not require any specific http-client implementation, that may be left for end user to satisfy, so I also updated the config to disable the `php-http/discovery` plugin to prevent that from getting re-added.