### PR TITLE
Optional 'start' parameter

### DIFF
--- a/src/Multipart/ResponseBuilder.php
+++ b/src/Multipart/ResponseBuilder.php
@@ -52,14 +52,17 @@ final readonly class ResponseBuilder implements ResponseBuilderInterface
         $mainPart = null;
         $attachments = $attachmentStorage->responseAttachments();
         foreach ($document->getParts() as $part) {
+            // When no "start" is provided, the first part should be considered the main part.
+            // @see https://datatracker.ietf.org/doc/html/rfc2387#section-3.2
             if (null === $mainPart && null === $start) {
                 $mainPart = $part;
                 continue;
             }
-            $mimeType = $part->getMimeType();
-            $id = string()->coerce($part->getHeader('Content-ID'));
 
-            if ((isset($start) && $start && $id === $start) || $mimeType === $soapType) {
+            $mimeType = $part->getMimeType();
+            $id = string()->coerce($part->getHeader('Content-ID', ''));
+
+            if ($start !== null && $id === $start) {
                 $mainPart = $part;
                 continue;
             }

--- a/tests/Unit/Multipart/ResponseBuilderTest.php
+++ b/tests/Unit/Multipart/ResponseBuilderTest.php
@@ -133,6 +133,58 @@ final class ResponseBuilderTest extends TestCase
         self::assertResponseAttachments($attachmentStorage, ['<attachment1@domain.com>', '<attachment2@domain.com>']);
     }
 
+    #[Test]
+    public function it_can_parse_multipart_without_start_parameter(): void
+    {
+        $attachmentStorage = self::createAttachmentsStore();
+        $responseFactory = Psr17FactoryDiscovery::findResponseFactory();
+        $streamFactory = Psr17FactoryDiscovery::findStreamFactory();
+        $boundary = '4acabd8e751e40993fe016a494eded6';
+
+        $multipartResponse = $responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'multipart/related; type="application/xop+xml"; boundary="' . $boundary. '"; start-info="text/xml"')
+            ->withBody($streamFactory->createStream(
+                <<<EORESPONSE
+                --{$boundary}
+                Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"
+                
+                <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+                    <SOAP-ENV:Body xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"/>
+                </SOAP-ENV:Envelope>
+                --{$boundary}
+                Content-ID: <attachment1@domain.com>
+                Content-Type: text/plain
+                Content-Disposition: attachment; name="file1"; filename="attachment1.txt"
+                Content-Transfer-Encoding: binary
+                
+                attachment1
+                --{$boundary}
+                Content-ID: <attachment2@domain.com>
+                Content-Type: text/plain
+                Content-Disposition: attachment; name="file2"; filename="attachment2.txt"
+                Content-Transfer-Encoding: binary
+                
+                attachment2
+                --{$boundary}--
+
+                EORESPONSE
+            ));
+
+        $responseBuilder = ResponseBuilder::default();
+        $actual = $responseBuilder($multipartResponse, $attachmentStorage, AttachmentType::Mtom);
+
+        static::assertSame($multipartResponse->getStatusCode(), $actual->getStatusCode());
+        static::assertSame(
+            <<<EOXML
+            <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+                <SOAP-ENV:Body xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"/>
+            </SOAP-ENV:Envelope>
+            EOXML,
+            (string) $actual->getBody()
+        );
+        self::assertResponseAttachments($attachmentStorage, ['<attachment1@domain.com>', '<attachment2@domain.com>']);
+    }
+
     private static function assertResponseAttachments(
         AttachmentStorage $storage,
         array $expectedIds = ['attachment1', 'attachment2']


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | #6 

#### Summary

This feature makes optional the 'start' parameter, and makes the first part of the multipart request the root part if 'start' is not specified.  I think this should be supported based on the spec [here](https://datatracker.ietf.org/doc/html/rfc2387#section-3.2).

The `Content-Type` headers as they are in the test that I've added are specifically what I encountered in the wild.  I'm very much unsure if they are "proper", and I was unsure what to name the test because of this, but this is what I was seeing and so therefore hoping could be supported.
