### PR TITLE
Replace azjezz/psl with php-standard-library/php-standard-library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php-http/multipart-stream-builder": "^1.4",
         "riverline/multipart-parser": "^2.1",
         "php-soap/psr18-transport": "^1.8",
-        "azjezz/psl": "^3.1 || ^4.0 || ^5.0"
+        "php-standard-library/php-standard-library": "^3.1 || ^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "nyholm/psr7": "^1.8",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "nyholm/psr7": "^1.8",
-        "php-soap/encoding": "~0.27",
+        "php-soap/encoding": "~0.28",
         "vimeo/psalm": "~6.13.0",
         "php-standard-library/psalm-plugin": "^2.3",
         "phpunit/phpunit": "~12.4",


### PR DESCRIPTION
## Summary
- Replace `azjezz/psl` with `php-standard-library/php-standard-library` (drop-in replacement)
- Add `^6.0` to the version constraint

## Context
Ref: phpro/soap-client#604

## Test plan
- [x] `composer validate` passes
- [x] `composer update` resolves successfully