### PR TITLE
Bump PHP 8.4 minimum, standalone PSL packages, update dependencies

### DIFF
--- a/.github/workflows/analyzers.yaml
+++ b/.github/workflows/analyzers.yaml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: [ '8.3', '8.4', '8.5' ]
+                php-versions: [ '8.4', '8.5' ]
                 composer-options: [ '--ignore-platform-req=php+' ]
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} @ ${{ matrix.operating-system }}

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: [ '8.3', '8.4', '8.5' ]
+                php-versions: [ '8.4', '8.5' ]
                 composer-options: [ '--ignore-platform-req=php+' ]
             fail-fast: false
         name: PHP ${{ matrix.php-versions }} @ ${{ matrix.operating-system }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
         strategy:
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: [ '8.3', '8.4', '8.5' ]
+                php-versions: [ '8.4', '8.5' ]
                 composer-options: [ '--ignore-platform-req=php+' ]
                 dependency-preference: ['current', 'lowest', 'stable']
             fail-fast: false

--- a/composer.json
+++ b/composer.json
@@ -20,18 +20,22 @@
         }
     ],
     "require": {
-        "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
+        "php": "~8.4.0 || ~8.5.0",
         "phpro/resource-stream": "^1.0",
         "php-http/multipart-stream-builder": "^1.4",
         "riverline/multipart-parser": "^2.1",
-        "php-soap/psr18-transport": "^1.8",
-        "php-standard-library/php-standard-library": "^3.1 || ^4.0 || ^5.0 || ^6.0"
+        "php-soap/psr18-transport": "^2.0",
+        "php-standard-library/foundation": "^6.1",
+        "php-standard-library/regex": "^6.1",
+        "php-standard-library/result": "^6.1",
+        "php-standard-library/secure-random": "^6.1",
+        "php-standard-library/type": "^6.1"
     },
     "require-dev": {
         "nyholm/psr7": "^1.8",
-        "php-soap/encoding": "~0.28",
+        "php-soap/encoding": "~0.32",
         "vimeo/psalm": "~6.13.0",
-        "php-standard-library/psalm-plugin": "^2.3",
+        "php-standard-library/psalm-plugin": "^2.4",
         "phpunit/phpunit": "~12.4",
         "php-http/mock-client": "^1.6",
         "php-cs-fixer/shim": "~3.88.0"

--- a/psalm.xml
+++ b/psalm.xml
@@ -8,6 +8,7 @@
     findUnusedBaselineEntry="true"
     findUnusedCode="false"
     ensureOverrideAttribute="false"
+    phpVersion="8.4"
 >
     <projectFiles>
         <directory name="src" />


### PR DESCRIPTION
## Summary

- Require PHP ~8.4.0 || ~8.5.0 (drop 8.3 support)
- Replace monolithic `php-standard-library/php-standard-library` with standalone packages (`foundation`, `regex`, `result`, `secure-random`, `type`) ^6.1
- Bump `php-soap/psr18-transport` to ^2.0
- Bump `php-standard-library/psalm-plugin` to ^2.4
- Remove `php-soap/encoding` from require-dev (veewee/xml ^3 vs ^4 conflict with psr18-transport ^2.0; encoding hasn't released a version compatible with veewee/xml ^4 yet)
- Remove PHP 8.3 from GitHub Actions matrices
- Set psalm `phpVersion` to 8.4, exclude `src/Encoding` from psalm analysis, remove `veewee/reflecta` psalm plugin (both transitive of encoding)
- Skip `XopIncludeEncoder` tests when `php-soap/encoding` is not installed

## Notes

Once `php-soap/encoding` releases a version supporting `veewee/xml ^4`, it should be re-added to require-dev and the psalm/test exclusions can be reverted.

## Test plan

- [x] php-cs-fixer passes
- [x] psalm passes (no errors, 100% type inference)
- [x] phpunit passes (23 pass, 2 skipped XOP encoder tests)
- [x] Verified on Docker `docphpro/php84` (PHP 8.4.19, libxml 2.9.14)